### PR TITLE
Refactor client-side api calls

### DIFF
--- a/client/src/components/datasets/DatasetViewer.tsx
+++ b/client/src/components/datasets/DatasetViewer.tsx
@@ -1,13 +1,5 @@
 import {useAuth} from 'contexts/auth';
-import {
-  query,
-  collection,
-  doc,
-  getDocs,
-  deleteDoc,
-  orderBy,
-} from 'firebase/firestore/lite';
-import {firestore} from 'lib/firestore';
+import {deleteDataset, getDatasets} from 'lib/api/datasets';
 import React, {ReactNode, useEffect, useState} from 'react';
 import {Dataset} from 'types/Dataset';
 
@@ -17,22 +9,18 @@ export default function DatasetViewer() {
 
   useEffect(() => {
     if (user) {
-      getDatasets();
+      getUserDatasets();
     }
   }, [user]);
 
-  async function getDatasets() {
-    const collectionRef = collection(firestore, `users/${user!.uid}/datasets`);
-    const datasetQuery = query(collectionRef, orderBy('name'));
-    const querySnapshot = await getDocs(datasetQuery);
-    const datasets = querySnapshot.docs.map(snapshot => snapshot.data());
-    setDatasets(datasets as Dataset[]);
+  async function getUserDatasets() {
+    const userDatasets = await getDatasets(user!);
+    setDatasets(userDatasets);
   }
 
-  async function deleteDataset(name: string) {
-    const docRef = doc(firestore, `users/${user?.uid}/datasets/${name}`);
-    await deleteDoc(docRef);
-    getDatasets();
+  async function _deleteDataset(name: string) {
+    await deleteDataset(user!, name);
+    getUserDatasets();
   }
 
   if (!user || datasets.length === 0) {
@@ -70,7 +58,7 @@ export default function DatasetViewer() {
               </td>
               <td className="table-padding text-blue-500 underline">View</td>
               <td className="table-padding text-right text-red-400">
-                <button onClick={() => deleteDataset(name)}>Delete</button>
+                <button onClick={() => _deleteDataset(name)}>Delete</button>
               </td>
             </tr>
           ))}

--- a/client/src/components/datasets/FileSelector.tsx
+++ b/client/src/components/datasets/FileSelector.tsx
@@ -1,8 +1,7 @@
 import {useAuth} from 'contexts/auth';
 import React, {useEffect, useState} from 'react';
-import {collection, orderBy, getDocs, query} from 'firebase/firestore/lite';
-import {firestore} from 'lib/firestore';
 import {UserFile} from 'types/UserFile';
+import {getUserFiles} from 'lib/api/files';
 
 interface Props {
   title: string;
@@ -29,11 +28,9 @@ export default function FileSelector({create, title, createPrompt}: Props) {
   }, [title]);
 
   async function getFiles() {
-    const collectionRef = collection(firestore, `users/${user!.uid}/files`);
-    const datasetQuery = query(collectionRef, orderBy('fileName'));
-    const querySnapshot = await getDocs(datasetQuery);
-    const files = querySnapshot.docs.map(snapshot => snapshot.data());
-    setFiles(files as UserFile[]);
+    if (!user) return;
+    const files = await getUserFiles(user);
+    setFiles(files);
     setSelected(
       new Map<string, boolean>(files.map(file => [file.fileName, false]))
     );

--- a/client/src/components/files/UploadView.tsx
+++ b/client/src/components/files/UploadView.tsx
@@ -48,7 +48,7 @@ export default function UploadingView({
 
   return (
     <div className="mt-8">
-      <p className="text-center text-3xl font-bold">Uploading Files</p>
+      <p className="text-center text-3xl font-bold">Uploading Files...</p>
       <div className="grid grid-cols-1">
         {uploads.map(props => (
           <FileUploader key={props.name} {...props} />

--- a/client/src/lib/api/datasets.ts
+++ b/client/src/lib/api/datasets.ts
@@ -1,0 +1,37 @@
+import {User} from 'firebase/auth';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  getDocs,
+  orderBy,
+  query,
+  setDoc,
+} from 'firebase/firestore/lite';
+import {firestore} from 'lib/firestore';
+import {Dataset} from 'types/Dataset';
+
+export async function getDatasets(user: User) {
+  const collectionRef = collection(firestore, `users/${user!.uid}/datasets`);
+  const datasetQuery = query(collectionRef, orderBy('name'));
+  const querySnapshot = await getDocs(datasetQuery);
+  const datasets = querySnapshot.docs.map(snapshot => snapshot.data());
+  return datasets as Dataset[];
+}
+
+export async function uploadDataset(user: User, dataset: Dataset) {
+  const docRef = doc(firestore, `users/${user.uid}/datasets/${dataset.name}`);
+  const docSnap = await getDoc(docRef);
+
+  // Check we're not overwriting anything
+  if (docSnap.exists()) {
+    throw new Error('A dataset with this name already exists!');
+  }
+  await setDoc(docRef, dataset);
+}
+
+export async function deleteDataset(user: User, datasetName: string) {
+  const docRef = doc(firestore, `users/${user?.uid}/datasets/${datasetName}`);
+  await deleteDoc(docRef);
+}

--- a/client/src/lib/api/files.ts
+++ b/client/src/lib/api/files.ts
@@ -1,0 +1,47 @@
+import {User} from 'firebase/auth';
+import {collection, getDocs, orderBy, query} from 'firebase/firestore/lite';
+import {firestore} from 'lib/firestore';
+import {urls} from 'lib/urls';
+import {UserFile} from 'types/UserFile';
+
+/**
+ * Generates signed upload urls for a supplied list of filenames and returns
+ * them in a map.
+ *
+ * @param user The user for which to execute the query
+ * @param fileNames A list of filenames
+ * @returns A map of filenames to their respective signed urls.
+ */
+export async function getSignedUploadURLs(user: User, fileNames: String[]) {
+  const data = {
+    file_names: [...fileNames],
+  };
+
+  const token = await user!.getIdToken();
+  const response = await fetch(urls.api.signFiles, {
+    method: 'POST',
+    mode: 'cors',
+    headers: new Headers({
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }),
+    body: JSON.stringify(data),
+  });
+
+  return new Map<string, string>(Object.entries(response.json()));
+}
+
+/**
+ * Gets a list of UserFiles for a given user, corresponding to the Firestore
+ * entries of the uploaded user files.
+ *
+ * @param user The user to query.
+ * @returns A list of UserFiles
+ */
+export async function getUserFiles(user: User) {
+  const collectionRef = collection(firestore, `users/${user!.uid}/files`);
+  const datasetQuery = query(collectionRef, orderBy('fileName'));
+  const querySnapshot = await getDocs(datasetQuery);
+  const files = querySnapshot.docs.map(snapshot => snapshot.data());
+  return files as UserFile[];
+}

--- a/client/src/lib/api/files.ts
+++ b/client/src/lib/api/files.ts
@@ -28,7 +28,8 @@ export async function getSignedUploadURLs(user: User, fileNames: String[]) {
     body: JSON.stringify(data),
   });
 
-  return new Map<string, string>(Object.entries(response.json()));
+  const result = await response.json();
+  return new Map<string, string>(Object.entries(result));
 }
 
 /**

--- a/client/src/lib/urls.ts
+++ b/client/src/lib/urls.ts
@@ -1,4 +1,7 @@
 export const urls = {
+  pages: {
+    home: '/',
+  },
   api: {
     signFiles: 'https://api.elpis.cloud/sign-files',
   },

--- a/client/src/pages/files.tsx
+++ b/client/src/pages/files.tsx
@@ -1,11 +1,11 @@
 import React, {useMemo, useState} from 'react';
 
 import {useAuth} from 'contexts/auth';
-import {urls} from 'lib/urls';
 import {UploadState} from 'types/UploadState';
 import WaitingView from 'components/files/WaitingView';
 import UploadingView from 'components/files/UploadView';
 import Prose from 'components/Prose';
+import {getSignedUploadURLs} from 'lib/api/files';
 
 export default function Files() {
   const {user} = useAuth();
@@ -42,28 +42,9 @@ export default function Files() {
   const uploadFiles = async () => {
     if (user === null || !canUpload) return;
     setUploadState('signing');
-    const signedURLs = await getSignedUploadURLs();
-    setSessionURLs(new Map<string, string>(Object.entries(signedURLs)));
+    const signedURLs = await getSignedUploadURLs(user, [...files.keys()]);
+    setSessionURLs(signedURLs);
     setUploadState('uploading');
-  };
-
-  const getSignedUploadURLs = async () => {
-    const data = {
-      file_names: [...files.keys()],
-    };
-
-    const token = await user!.getIdToken();
-    const response = await fetch(urls.api.signFiles, {
-      method: 'POST',
-      mode: 'cors',
-      headers: new Headers({
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      }),
-      body: JSON.stringify(data),
-    });
-
-    return response.json();
   };
 
   const reset = () => {

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import type {NextPage} from 'next';
 import {FormattedMessage} from 'react-intl';
-import {Container, Header, Image} from 'semantic-ui-react';
+import {Container, Image} from 'semantic-ui-react';
 
 const Home: NextPage = () => {
   return (

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -1,5 +1,6 @@
 import {useAuth} from 'contexts/auth';
 import {signOut} from 'lib/auth';
+import {urls} from 'lib/urls';
 import {useRouter} from 'next/router';
 import React, {useEffect} from 'react';
 
@@ -9,7 +10,7 @@ export default function profile() {
 
   useEffect(() => {
     if (user === null) {
-      router.push('/');
+      router.push(urls.pages.home);
     }
   });
 


### PR DESCRIPTION
Client-side api calls were being done in the components, which is not particularly scalable, or neat.
- A folder for these calls was created under /lib/api
- The existing api calls within the components were moved to this folder.