### PR TITLE
Minor refactor of `delete_datasets` to use Dataset class and upacking utilities

### DIFF
--- a/functions/functions/datasets/delete_datasets.py
+++ b/functions/functions/datasets/delete_datasets.py
@@ -2,8 +2,13 @@ import os
 from typing import Dict
 
 from functions_framework import Context
+from humps.main import decamelize
 from loguru import logger
+from models import Dataset
 from utils.cloud_storage import delete_folder_blob
+from utils.firestore_event_converter import unpack
+
+DATASET_BUCKET_NAME = os.environ.get("USER_DATASETS_BUCKET", "dataset_bucket")
 
 
 def delete_dataset_from_bucket(data: Dict, context: Context) -> None:
@@ -18,14 +23,14 @@ def delete_dataset_from_bucket(data: Dict, context: Context) -> None:
         context (Context): Metadata for the event.
 
     """
-    logger.info(f"Data: {data}")
-    logger.info(f"Context: {context}")
+    logger.info("Cloud storage cleanup after firestore dataset deletion...")
+    logger.info(f"Raw firestore dataset event: {data}")
 
-    dataset = data["oldValue"]
-    uid = dataset["fields"]["userId"]["stringValue"]
-    dataset_name = dataset["fields"]["name"]["stringValue"]
+    dataset = decamelize(unpack(data["oldValue"]))
+    dataset = Dataset.from_dict(dataset)
 
-    datasets_bucket_name = os.environ.get("USER_DATASETS_BUCKET")
     delete_folder_blob(
-        bucket_name=datasets_bucket_name, target_blob_prefix=f"{uid}/{dataset_name}/"
+        bucket_name=DATASET_BUCKET_NAME,
+        target_blob_prefix=f"{dataset.user_id}/{dataset.name}/",
     )
+    logger.success(f"Successfully deleted dataset: {dataset.user_id}/{dataset.name}/")


### PR DESCRIPTION
This is in the hopes of trying to standardize using the model classes for firestore events.