### PR TITLE
Migrate frontend build script from gsutil -> gcloud. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # ElpisCloud
+
 [elpis.cloud](https://elpis.cloud)
 
-A rework of the [ELPIS Project](https://github.com/CoEDL/elpis), but cloud-based and chic. 
+A rework of the [ELPIS Project](https://github.com/CoEDL/elpis), but cloud-based and chic.
 
 Our documentation is being written [here](https://docs.elpis.cloud).
 
 ## Overview
-This is a monorepo containing all the infrastructure and documentation for the project. 
+
+This is a monorepo containing all the infrastructure and documentation for the project.
 Development is still ongoing, with only the inference flow and user management to go before public release.
 
 ### Stack
+
 We're using:
+
 - [GCP](https://cloud.google.com/) as our cloud provider.
 - [terraform](https://www.terraform.io/) to manage our cloud infrastructure.
 - [firebase](https://firebase.google.com/) for auth and firestore.
@@ -18,11 +22,16 @@ We're using:
 - [poetry](https://python-poetry.org/) and Python3.10 for the backend.
 
 ### Repo Structure
+
 - `architecture/`: Where the terraform files live, which define our cloud architecture.
 - `client/`: The frontend files.
-- `functions/`: The cloud function source. 
+- `functions/`: The cloud function source.
 - `services/`: Cloud run services, w docker images.
 - `docs/`: The documentation source.
 - `scripts/`: Some useful utilities.
 
+## Uploading the frontend
 
+_(TODO, move this to docs)_
+From the root directory, run `./scripts/upload_frontend.sh prod`. The frontend
+will make a static export, and then copy these files across to the bucket.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,12 @@ We're using:
 - `docs/`: The documentation source.
 - `scripts/`: Some useful utilities.
 
-## Uploading the frontend
+## Exporting the frontend files.
 
 _(TODO, move this to docs)_
-From the root directory, run `./scripts/upload_frontend.sh prod`. The frontend
-will make a static export, and then copy these files across to the bucket.
+For the steps below, the `gcloud` CLI tools are required [(see here)](https://formulae.brew.sh/cask/google-cloud-sdk).
+
+1. Make sure you are signed into an account with iam privileges for the elpis frontend bucket.
+2. Set your project to 'elpiscloud': `gcloud config set project elpiscloud`
+3. From the root directory, run `./scripts/upload_frontend.sh prod`. The frontend
+   will make a static export, and then copy these files across to the bucket.

--- a/scripts/upload_frontend.sh
+++ b/scripts/upload_frontend.sh
@@ -6,4 +6,4 @@ cd client
 yarn install && yarn build
 
 # Upload static files
-gcloud storage cp --recursive "out" "gs://elpiscloud-$env-site"
+gcloud storage cp --recursive "out/*" "gs://elpiscloud-$env-site"

--- a/scripts/upload_frontend.sh
+++ b/scripts/upload_frontend.sh
@@ -6,4 +6,4 @@ cd client
 yarn install && yarn build
 
 # Upload static files
-gsutil -m rsync -r -c -d "out" "gs://elpiscloud-$env-site"
+gcloud storage cp --recursive "out" "gs://elpiscloud-$env-site"


### PR DESCRIPTION
`Gsutil` is being replaced by  the `gcloud` cli and so this is just a minor change to address that. 