### PR TITLE
Fix invalid checks for determining if a dataset has been processed. 

### DIFF
--- a/functions/functions/datasets/process_file.py
+++ b/functions/functions/datasets/process_file.py
@@ -214,9 +214,23 @@ def post_processing_hook(job: ProcessingJob) -> None:
 def has_finished_processing(
     dataset_files: List[str], processed_files: List[str]
 ) -> bool:
+    """Checks whether the dataset has finished processing.
 
-    # Check that the length of each is equal, and if so, set dataset to be processed.
+    Parameters:
+        dataset_files: A list of names of the files in the dataset.
+        processed_files: A list of names of files uploaded to cloud storage for
+            the corresponding dataset.
+
+    Returns:
+        true iff the supplied list of processed files would be a valid
+        processed dataset for the initial files.
+    """
+
     required_stems = {Path(name).stem for name in dataset_files}
-    # Gives back the
-    uploaded_stems = {Path(name).stem.split("_")[0] for name in processed_files}
-    return required_stems == uploaded_stems
+    uploaded_stems = {Path(name).stem for name in processed_files}
+
+    def is_processed(required_stem: str) -> bool:
+        starts_with_required_stem = lambda stem: stem.startswith(required_stem)
+        return any(map(starts_with_required_stem, uploaded_stems))
+
+    return all(map(is_processed, required_stems))

--- a/functions/tests/functions/test_process_file.py
+++ b/functions/tests/functions/test_process_file.py
@@ -90,6 +90,13 @@ def test_has_finished_processing():
     assert has_finished_processing(ABUI_DATASET_FILES, processed_files)
 
 
+def test_has_finished_procesing_with_path_prefixes():
+    processed_files = ["abui_1.json", "abui_1.wav", "abui_2.json", "abui_2.wav"]
+    prefix = "someUserId/datasetName/"
+    processed_files = [prefix + name for name in processed_files]
+    assert has_finished_processing(ABUI_DATASET_FILES, processed_files)
+
+
 def test_has_finished_processing_with_incomplete_files_should_return_false():
     processed_files = ["abui_1.json", "abui_1.wav"]
     assert not has_finished_processing(ABUI_DATASET_FILES, processed_files)

--- a/functions/tests/functions/test_process_file.py
+++ b/functions/tests/functions/test_process_file.py
@@ -30,6 +30,9 @@ TEST_JOB = ProcessingJob(
 )
 
 
+ABUI_DATASET_FILES = ["abui_1.eaf", "abui_1.wav", "abui_2.eaf", "abui_2.wav"]
+
+
 def test_download_files(mocker):
     downloader_mock: Mock = mocker.patch(
         "functions.datasets.process_file.download_blob"
@@ -83,27 +86,32 @@ def test_generate_training_files_with_timed_annotation(tmp_path: Path, mocker):
 
 
 def test_has_finished_processing():
-    dataset_files = ["1.eaf", "1.wav", "2.eaf", "2.wav"]
-    processed_files = ["1.json", "1.wav"]
-    assert not has_finished_processing(dataset_files, processed_files)
+    processed_files = ["abui_1.json", "abui_1.wav", "abui_2.json", "abui_2.wav"]
+    assert has_finished_processing(ABUI_DATASET_FILES, processed_files)
 
-    processed_files = ["1.json", "1.wav", "2.json", "2.wav"]
-    assert has_finished_processing(dataset_files, processed_files)
 
+def test_has_finished_processing_with_incomplete_files_should_return_false():
+    processed_files = ["abui_1.json", "abui_1.wav"]
+    assert not has_finished_processing(ABUI_DATASET_FILES, processed_files)
+
+
+def test_has_finished_processing_with_timed_annotations():
     processed_files = [
-        "1.json",
-        "1.wav",
-        "2_1000.json",
-        "2_1000.wav",
+        "abui_1.json",
+        "abui_1.wav",
+        "abui_2_1000.json",
+        "abui_2_1000.wav",
     ]
-    assert has_finished_processing(dataset_files, processed_files)
+    assert has_finished_processing(ABUI_DATASET_FILES, processed_files)
 
+
+def test_has_finished_processing_with_timed_and_multiple_annotations():
     processed_files = [
-        "1.json",
-        "1.wav",
-        "2_1000.json",
-        "2_1000.wav",
-        "2_3000.json",
-        "2_3000.wav",
+        "abui_1.json",
+        "abui_1.wav",
+        "abui_2_1000.json",
+        "abui_2_1000.wav",
+        "abui_2_3000.json",
+        "abui_2_3000.wav",
     ]
-    assert has_finished_processing(dataset_files, processed_files)
+    assert has_finished_processing(ABUI_DATASET_FILES, processed_files)


### PR DESCRIPTION
Previous to this PR, it was wrongly assumed that if an underscore existed in an uploaded file name, it must have been placed there by the processing stage (which adds a underscored timing suffix for timed annotations in case there are multiple annotattions for the same audio file).

Obviously, file names can include underscores 🤦  

### Changes:
- Address file names having underscores.
- Add missing docstring.
- Split tests which check if the dataset has been processed into individual cases. 
- Add test for cloud storage path prefixes.