### PR TITLE
Use pedalboard for audio utilities

### DIFF
--- a/functions/functions/datasets/process_file.py
+++ b/functions/functions/datasets/process_file.py
@@ -48,7 +48,7 @@ def process_dataset_file(event, context) -> None:
         annotation.sample_rate = sample_rate
 
     audio.resample(
-        audio_file=audio_file, destination=audio_file, sample_rate=TARGET_SAMPLE_RATE
+        audio_path=audio_file, destination=audio_file, sample_rate=TARGET_SAMPLE_RATE
     )
     annotations = map(
         lambda annotation: annotation.rescale_timestamps(sample_rate), annotations
@@ -155,7 +155,7 @@ def generate_training_files(
     if annotation.is_timed():
         cut_audio_file = dir / f"{name}.wav"
         audio.cut(
-            audio_file=audio_file,
+            audio_path=audio_file,
             destination=cut_audio_file,
             start_ms=annotation.start_ms,  # type: ignore
             stop_ms=annotation.stop_ms,  # type: ignore

--- a/functions/poetry.lock
+++ b/functions/poetry.lock
@@ -484,6 +484,17 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
+name = "pedalboard"
+version = "0.6.2"
+description = "A Python library for adding effects to audio."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+numpy = "*"
+
+[[package]]
 name = "pluggy"
 version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
@@ -727,7 +738,7 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "41fe1f2cdb82afc084f05a37bd463590594fe11bb3eecdf5dd34610531c1baf3"
+content-hash = "2cdeba3b22b57b492726842a971db65116e86019f09a1b734e85b7a179ef0e4b"
 
 [metadata.files]
 attrs = []
@@ -768,6 +779,7 @@ msgpack = []
 nodeenv = []
 numpy = []
 packaging = []
+pedalboard = []
 pluggy = []
 proto-plus = []
 protobuf = []

--- a/functions/pyproject.toml
+++ b/functions/pyproject.toml
@@ -17,6 +17,7 @@ Flask = "2.0.2"
 loguru = "^0.6.0"
 cloudevents = "^1.6.1"
 pyhumps = "^3.7.3"
+pedalboard = "^0.6.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.3"

--- a/functions/tests/utils/test_audio.py
+++ b/functions/tests/utils/test_audio.py
@@ -16,16 +16,18 @@ def test_cut(tmp_path: Path):
     stop_ms = 1000
     sample_rate = get_sample_rate(audio)
     cut(
-        audio_file=audio,
+        audio_path=audio,
         destination=cut_audio,
         start_ms=start_ms,
         stop_ms=stop_ms,
     )
 
     audio_wave = wave.open(str(cut_audio), "rb")
-    assert audio_wave.getnframes() == (stop_ms - start_ms) * sample_rate / 1000
-    assert audio_wave.getframerate() == sample_rate
+    frame_count = audio_wave.getnframes()
     audio_wave.close()
+
+    assert frame_count == (stop_ms - start_ms) * sample_rate / 1000
+    assert sample_rate == get_sample_rate(cut_audio)
 
 
 def test_resample(tmp_path: Path):
@@ -35,8 +37,10 @@ def test_resample(tmp_path: Path):
     assert resampled_audio.exists()
 
     resampled_audio_wave = wave.open(str(resampled_audio), "rb")
-    assert resampled_audio_wave.getframerate() == TARGET_SAMPLE_RATE
+    sample_rate = resampled_audio_wave.getframerate()
     resampled_audio_wave.close()
+
+    assert sample_rate == TARGET_SAMPLE_RATE
 
 
 def test_get_sample_rate():


### PR DESCRIPTION
Fixes #78 

These changes make use the pedalboard library from spotify for its audio utilities (thanks @fauxneticien for the recommendation).