### PR TITLE
Improve Annotation model

### DIFF
--- a/functions/functions/datasets/process_file.py
+++ b/functions/functions/datasets/process_file.py
@@ -42,16 +42,9 @@ def process_dataset_file(event, context) -> None:
     transcription_file, audio_file = download_files(job)
     annotations = extract_annotations(transcription_file, job.options.elan_options)
 
-    # Resample audio and annotations to standardise for training
-    sample_rate = audio.get_sample_rate(audio_file)
-    for annotation in annotations:
-        annotation.sample_rate = sample_rate
-
+    # Resample audio to standardise for training
     audio.resample(
         audio_file=audio_file, destination=audio_file, sample_rate=TARGET_SAMPLE_RATE
-    )
-    annotations = map(
-        lambda annotation: annotation.rescale_timestamps(sample_rate), annotations
     )
 
     # Clean the annotations

--- a/functions/models/annotation.py
+++ b/functions/models/annotation.py
@@ -15,35 +15,12 @@ class Annotation:
     speaker_id: Optional[str] = None  # Currently unused
     start_ms: Optional[int] = None
     stop_ms: Optional[int] = None
-    sample_rate: Optional[int] = None
 
     def is_timed(self) -> bool:
-        return (
-            self.sample_rate is not None
-            and self.start_ms is not None
-            and self.stop_ms is not None
-        )
-
-    def rescale_timestamps(self, sample_rate: int) -> "Annotation":
-        """Creates a new annotation, with a modified start_ms and end_ms to fit
-        the transcript under the new sample_rate.
-
-        Parameters:
-            old_sample_rate: The old sample rate of the annotation.
-            sample_rate: The new sample rate of the annotation.
-
-        Returns:
-            The modified annotation.
+        """Returns true iff the annotation exists between a start and stop time for
+        the given recording.
         """
-        result = copy(self)
-        if not self.is_timed():
-            return result
-
-        scale = self.sample_rate / sample_rate  # type: ignore
-        # Make sure to always contain transcript
-        result.start_ms = int(self.start_ms * scale)
-        result.stop_ms = int(self.stop_ms * scale) + 1
-        return result
+        return self.start_ms is not None and self.stop_ms is not None
 
     def to_dict(self) -> Dict[str, Any]:
         """Converts an annotation to a serializable dictionary"""
@@ -60,6 +37,5 @@ class Annotation:
             transcript=data["transcript"],
             start_ms=data.get("start_ms"),
             stop_ms=data.get("stop_ms"),
-            sample_rate=data.get("sample_rate"),
             speaker_id=data.get("speaker_id"),
         )

--- a/functions/tests/functions/test_process_file.py
+++ b/functions/tests/functions/test_process_file.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock
 from models import Annotation, DatasetOptions, ProcessingJob
 
 from functions.datasets.process_file import (
-    TARGET_SAMPLE_RATE,
     clean_annotation,
     download_files,
     generate_training_files,
@@ -18,7 +17,6 @@ TEST_ANNOTATION_TIMED = Annotation(
     transcript="hi",
     start_ms=0,
     stop_ms=1000,
-    sample_rate=TARGET_SAMPLE_RATE,
 )
 
 TEST_JOB = ProcessingJob(

--- a/functions/tests/models/test_annotations.py
+++ b/functions/tests/models/test_annotations.py
@@ -1,16 +1,45 @@
 from models import Annotation
 from pytest import raises
 
-VALID_ANNOTATION_DATA = {"audio_file_name": "audio", "transcript": "hi there"}
-INVALID_ANNOTATION_DATA = {"audio_file_name": "audio"}
+START = 0
+STOP = 1000
+AUDIO_FILE_NAME = "audio"
+TRANSCRIPT = "hi"
+SPEAKER_ID = "goofy"
+
+INVALID_ANNOTATION_DATA = {"audio_file_name": AUDIO_FILE_NAME}
+UNTIMED_ANNOTATION_DATA = {
+    "audio_file_name": AUDIO_FILE_NAME,
+    "transcript": TRANSCRIPT,
+    "speaker_id": SPEAKER_ID,
+}
+TIMING_DATA = {"start_ms": START, "stop_ms": STOP}
+TIMED_ANNOTATION_DATA = UNTIMED_ANNOTATION_DATA | TIMING_DATA
 
 
 def test_annotation_from_valid_dict():
-    a = Annotation.from_dict(VALID_ANNOTATION_DATA)
-    assert a.audio_file_name == "audio"
-    assert a.transcript == "hi there"
+    annotation = Annotation.from_dict(UNTIMED_ANNOTATION_DATA)
+    assert annotation.audio_file_name == AUDIO_FILE_NAME
+    assert annotation.transcript == TRANSCRIPT
+
+    annotation = Annotation.from_dict(TIMED_ANNOTATION_DATA)
+    assert annotation.start_ms == START
+    assert annotation.stop_ms == STOP
 
 
 def test_annotation_from_invalid_dict():
     with raises(Exception):
         Annotation.from_dict(INVALID_ANNOTATION_DATA)
+
+
+def test_to_dict_round_trip():
+    timed_annotation = Annotation.from_dict(TIMED_ANNOTATION_DATA)
+    assert timed_annotation.to_dict() == TIMED_ANNOTATION_DATA
+
+
+def test_is_timed():
+    timed_annotation = Annotation.from_dict(TIMED_ANNOTATION_DATA)
+    assert timed_annotation.is_timed()
+
+    untimed_annotation = Annotation.from_dict(UNTIMED_ANNOTATION_DATA)
+    assert not untimed_annotation.is_timed()


### PR DESCRIPTION
When I wrote the annotation class, I thought that when resampling an audio clip, the annotation timestamps would have to change as well. 

This was wrong and means that annotations don't even need to know about the sample rate of their given audio file at all.

## Changes
- Removed sample_rate and rescaling method from annotations
- Add is_timed docstring
- Improved tests for annotations