### PR TITLE
Add CI for running pytest on cloud functions

### DIFF
--- a/.github/workflows/cloudFunctionTests.yml
+++ b/.github/workflows/cloudFunctionTests.yml
@@ -1,0 +1,37 @@
+name: Cloud Function Tests
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "functions/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "functions/**"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Setup poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: "1.1.13"
+
+      - name: Poetry install
+        run: |
+          cd functions
+          poetry install
+
+      - name: Run pytest
+        run: |
+          cd functions
+          poetry run pytest -vv


### PR DESCRIPTION
Now that we have some tests it would be nice to show that their status during pull requests.

This github action setups up the cloud functions environment and runs pytest.