### PR TITLE
Fix trainer topic subscription incompatible terraform options. 

### DIFF
--- a/architecture/modules/service/main.tf
+++ b/architecture/modules/service/main.tf
@@ -38,10 +38,9 @@ resource "google_project_iam_binding" "project" {
 }
 
 resource "google_pubsub_subscription" "subscription" {
-  name                         = "${var.service_name}_subscription"
-  topic                        = var.topic.name
-  ack_deadline_seconds         = 30
-  enable_exactly_once_delivery = true
+  name                 = "${var.service_name}_subscription"
+  topic                = var.topic.name
+  ack_deadline_seconds = 30
 
   push_config {
     push_endpoint = google_cloud_run_service.default.status[0].url


### PR DESCRIPTION
Fixes #88 
There's actually something else here to think about, which is that without the `exactly_once_delivery` option, the topic has the chance to fire the same event multiple times.

- I think the server then should be keeping track of what training jobs it's fulfilling before it begins the training process. 
- The server can't directly keep track of this because of cloud run instances (one job might be sent to two instances which don't know about eachother).
- Maybe I just put it as a flag on the firestore Model that training has begun? 